### PR TITLE
Adjust _media.scss to show image size option

### DIFF
--- a/framework/admin/assets/scss/options/_media.scss
+++ b/framework/admin/assets/scss/options/_media.scss
@@ -35,7 +35,7 @@
   .attachment-display-settings .setting {
     display: none;
   }
-  .attachment-display-settings label.setting:last-child {
+  .attachment-display-settings .setting:last-child {
     display: block;
   }
   .setting span {

--- a/framework/admin/assets/scss/options/_media.scss
+++ b/framework/admin/assets/scss/options/_media.scss
@@ -35,7 +35,7 @@
   .attachment-display-settings .setting {
     display: none;
   }
-  .attachment-display-settings .setting:last-child {
+  .tb-modal-advanced-image .media-sidebar .attachment-display-settings .setting:last-child {
     display: block;
   }
   .setting span {


### PR DESCRIPTION
The current label selector is not present in the html so the size option is not showing and the most recent size is being auto-selected.